### PR TITLE
Correct branch on PRs

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,11 +1,13 @@
 name: buildkite-pipeline
-on: [push]
+on:
+  pull_request:
+    types: [opened, ready_for_review, synchronize, reopened]
 
 jobs:
   trigger:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v2
     - name: Trigger pipeline
       id: run
       uses: ./

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This action triggers a [https://buildkite.com/](Buildkite) pipeline and (by defa
 
 ## Why not use the official action?
 
-The [official Buildkite action](https://github.com/buildkite/trigger-pipeline-action) appears to be abandoned as it hasn't had any changes in nearly a year, and is missing essential functionality such as the ability to wait until a pipeline is finished.
+The [official Buildkite action](https://github.com/buildkite/trigger-pipeline-action) appears to be abandoned as it hasn't had any changes in nearly a year, is missing essential functionality such as the ability to wait until a pipeline is finished, and has a number of bugs such as using the wrong branch name on `pull_request` events.
 
 ## Inputs
 

--- a/main.py
+++ b/main.py
@@ -25,7 +25,7 @@ class ActionContext:
             author=ActionContext.__author(env["GITHUB_EVENT_PATH"]),
             access_token=env["INPUT_ACCESS_TOKEN"],
             pipeline=env["INPUT_PIPELINE"],
-            branch=env.get("INPUT_BRANCH") or ActionContext.__branch(env["GITHUB_REF"]),
+            branch=env.get("INPUT_BRANCH") or ActionContext.__branch(env),
             commit=env.get("INPUT_COMMIT") or env["GITHUB_SHA"],
             message=env["INPUT_MESSAGE"],
             env=json.loads(env.get("INPUT_ENV") or "{}"),
@@ -40,10 +40,16 @@ class ActionContext:
             return event_data.get("pusher", {})
 
     @staticmethod
-    def __branch(git_ref: str) -> str:
+    def __branch(env: Dict[str, str]) -> str:
+        head_ref = env.get("GITHUB_HEAD_REF")  # branch name on pull requests
+        if head_ref:
+            return head_ref
+
+        git_ref = env["GITHUB_REF"]
         prefix = "refs/heads/"
         if git_ref.startswith(prefix):
             return git_ref[len(prefix):]
+
         return git_ref
 
 


### PR DESCRIPTION
Using `GITHUB_REF` and stripping the prefix gives you the correct branch for `push` events, but for `pull_requests` it can get the wrong branch if it ends up being a merge commit. Using the `GITHUB_HEAD_REF` variable (only available for `pull_request` events) gives you the pull request branch name directly.